### PR TITLE
Use incrementing_weights, fix comment

### DIFF
--- a/calculate_predictions.py
+++ b/calculate_predictions.py
@@ -3,7 +3,7 @@ from os import listdir
 from datetime import date
 import csv
 from hardcoded_predictions import HARDCODED_PREDICTIONS
-from weights_functions import exponential_weights
+from weights_functions import incrementing_weights
 
 AMOUNT = 'Amount'
 CATEGORY = 'Category'
@@ -91,7 +91,7 @@ def weighted_avg(vals, weights):
 Returns a dictionary in the form
 { category (string): prediction (float) }
 '''
-def compute_predictions(year, month_num, weights_function=exponential_weights):
+def compute_predictions(year, month_num, weights_function=incrementing_weights):
     filenames = get_transaction_filenames(year, month_num)
     if len(filenames) == 0:
         print(f'NO FILES PRE-{month_num}/{year}')

--- a/weights_functions.py
+++ b/weights_functions.py
@@ -6,6 +6,6 @@ def exponential_weights(num_weights):
 def even_weights(num_weights):
     return [1]*num_weights
 
-# Returns [num_weights, num_weights -1, ..., 1]
+# Returns [1, 2, ..., num_weights]
 def incrementing_weights(num_weights):
     return list(range(1, num_weights+1))


### PR DESCRIPTION
As per #1 `incrementing_weights` performs best both for all-time (Jan 2021 to October 2022) and for just 2022, so this PR makes that the default function used for the predictions computation.